### PR TITLE
iOS: honour videoBitrate via fileLengthLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,11 @@ VVideoAdvancedConfig(
 )
 ```
 
+On iOS, `videoBitrate` is approximated through AVFoundation's total output-size
+limit and may vary slightly from the requested rate. `audioBitrate` is not an
+independent AVAssetExportSession control; iOS chooses it as part of the export
+preset.
+
 ## 🖼️ **Thumbnail Generation**
 
 ### Single Thumbnail

--- a/example/integration_test/ios_compression_feature_audit_test.dart
+++ b/example/integration_test/ios_compression_feature_audit_test.dart
@@ -17,6 +17,13 @@ void main() {
   const inspectionChannel = MethodChannel(
     'v_video_compressor_example/inspection',
   );
+  const requiredBitrateFeatures = <String>{
+    'video bitrate',
+    'video bitrate without audio',
+    'trimmed video bitrate',
+    'trimmed video bitrate without audio',
+    'H.265 video bitrate',
+  };
   final compressor = VVideoCompressor();
   final generatedFiles = <String>{};
   final generatedDirectories = <String>{};
@@ -85,6 +92,24 @@ void main() {
       throw StateError('Native inspection returned null for $path');
     }
     return result;
+  }
+
+  double averageTotalBitrate(Map<String, dynamic> info) {
+    final durationMillis = (info['durationMillis'] as num).toDouble();
+    final fileSizeBytes = (info['fileSizeBytes'] as num).toDouble();
+    return fileSizeBytes * 8 * 1000 / durationMillis;
+  }
+
+  int maximumBudgetedFileSize(
+    Map<String, dynamic> info, {
+    required int videoBitrate,
+    required double audioBitrate,
+  }) {
+    final durationSeconds = (info['durationMillis'] as num).toDouble() / 1000;
+    final requestedBytes = (videoBitrate + audioBitrate) * durationSeconds / 8;
+    // AVAssetExportSession can exceed fileLengthLimit, especially on short
+    // clips. Keep the audit bounded while allowing container/startup overhead.
+    return (requestedBytes * 1.10 + 64 * 1024).ceil();
   }
 
   Future<VVideoCompressionResult> compress(
@@ -486,13 +511,165 @@ void main() {
         () async {
           final result = await compress(
             publicPath,
+            quality: VVideoCompressQuality.low,
             advanced: const VVideoAdvancedConfig(videoBitrate: 250000),
           );
           final info = await inspect(result.compressedFilePath);
           final bitrate = (info['videoEstimatedDataRate'] as num).toDouble();
+          final totalBitrate = averageTotalBitrate(info);
+          final maximumFileSize = maximumBudgetedFileSize(
+            info,
+            videoBitrate: 250000,
+            audioBitrate: (source['audioEstimatedDataRate'] as num).toDouble(),
+          );
           return (
-            passed: bitrate <= 400000,
-            actual: 'estimatedDataRate=${bitrate.round()} bps',
+            passed: (info['fileSizeBytes'] as num) <= maximumFileSize,
+            actual:
+                'estimatedDataRate=${bitrate.round()} bps, '
+                'averageTotalBitrate=${totalBitrate.round()} bps, '
+                'fileSize=${info['fileSizeBytes']} B, '
+                'maximumFileSize=$maximumFileSize B',
+          );
+        },
+      );
+
+      await verify(
+        'video bitrate without audio',
+        'A video-only 250 kbps request does not reserve an audio budget',
+        () async {
+          final result = await compress(
+            publicPath,
+            quality: VVideoCompressQuality.low,
+            advanced: const VVideoAdvancedConfig(
+              videoBitrate: 250000,
+              removeAudio: true,
+            ),
+          );
+          final info = await inspect(result.compressedFilePath);
+          final bitrate = (info['videoEstimatedDataRate'] as num).toDouble();
+          final totalBitrate = averageTotalBitrate(info);
+          final maximumFileSize = maximumBudgetedFileSize(
+            info,
+            videoBitrate: 250000,
+            audioBitrate: 0,
+          );
+          return (
+            passed:
+                info['hasAudio'] == false &&
+                (info['fileSizeBytes'] as num) <= maximumFileSize,
+            actual:
+                'hasAudio=${info['hasAudio']}, '
+                'estimatedDataRate=${bitrate.round()} bps, '
+                'averageTotalBitrate=${totalBitrate.round()} bps, '
+                'fileSize=${info['fileSizeBytes']} B, '
+                'maximumFileSize=$maximumFileSize B',
+          );
+        },
+      );
+
+      await verify(
+        'trimmed video bitrate',
+        'A trimmed 250 kbps request budgets only the exported duration',
+        () async {
+          final result = await compress(
+            publicPath,
+            quality: VVideoCompressQuality.low,
+            advanced: const VVideoAdvancedConfig(
+              videoBitrate: 250000,
+              trimStartMs: 500,
+              trimEndMs: 2500,
+            ),
+          );
+          final info = await inspect(result.compressedFilePath);
+          final bitrate = (info['videoEstimatedDataRate'] as num).toDouble();
+          final durationMs = (info['durationMillis'] as num).toInt();
+          final totalBitrate = averageTotalBitrate(info);
+          final maximumFileSize = maximumBudgetedFileSize(
+            info,
+            videoBitrate: 250000,
+            audioBitrate: (source['audioEstimatedDataRate'] as num).toDouble(),
+          );
+          return (
+            passed:
+                (info['fileSizeBytes'] as num) <= maximumFileSize &&
+                durationMs >= 1700 &&
+                durationMs <= 2300,
+            actual:
+                'durationMs=$durationMs, '
+                'estimatedDataRate=${bitrate.round()} bps, '
+                'averageTotalBitrate=${totalBitrate.round()} bps, '
+                'fileSize=${info['fileSizeBytes']} B, '
+                'maximumFileSize=$maximumFileSize B',
+          );
+        },
+      );
+
+      await verify(
+        'trimmed video bitrate without audio',
+        'A trimmed composition uses its exported duration and no audio budget',
+        () async {
+          final result = await compress(
+            publicPath,
+            quality: VVideoCompressQuality.low,
+            advanced: const VVideoAdvancedConfig(
+              videoBitrate: 250000,
+              removeAudio: true,
+              trimStartMs: 500,
+              trimEndMs: 2500,
+            ),
+          );
+          final info = await inspect(result.compressedFilePath);
+          final durationMs = (info['durationMillis'] as num).toInt();
+          final totalBitrate = averageTotalBitrate(info);
+          final maximumFileSize = maximumBudgetedFileSize(
+            info,
+            videoBitrate: 250000,
+            audioBitrate: 0,
+          );
+          return (
+            passed:
+                info['hasAudio'] == false &&
+                (info['fileSizeBytes'] as num) <= maximumFileSize &&
+                durationMs >= 1700 &&
+                durationMs <= 2300,
+            actual:
+                'hasAudio=${info['hasAudio']}, durationMs=$durationMs, '
+                'averageTotalBitrate=${totalBitrate.round()} bps, '
+                'fileSize=${info['fileSizeBytes']} B, '
+                'maximumFileSize=$maximumFileSize B',
+          );
+        },
+      );
+
+      await verify(
+        'H.265 video bitrate',
+        'A 1 Mbps explicit bitrate budget also applies to H.265 exports',
+        () async {
+          final result = await compress(
+            publicPath,
+            advanced: const VVideoAdvancedConfig(
+              videoBitrate: 1000000,
+              videoCodec: VVideoCodec.h265,
+            ),
+          );
+          final info = await inspect(result.compressedFilePath);
+          final bitrate = (info['videoEstimatedDataRate'] as num).toDouble();
+          final totalBitrate = averageTotalBitrate(info);
+          final codec = info['videoCodec'];
+          final maximumFileSize = maximumBudgetedFileSize(
+            info,
+            videoBitrate: 1000000,
+            audioBitrate: (source['audioEstimatedDataRate'] as num).toDouble(),
+          );
+          return (
+            passed:
+                (codec == 'hvc1' || codec == 'hev1') &&
+                (info['fileSizeBytes'] as num) <= maximumFileSize,
+            actual:
+                'codec=$codec, estimatedDataRate=${bitrate.round()} bps, '
+                'averageTotalBitrate=${totalBitrate.round()} bps, '
+                'fileSize=${info['fileSizeBytes']} B, '
+                'maximumFileSize=$maximumFileSize B',
           );
         },
       );
@@ -1029,6 +1206,19 @@ void main() {
           ifAbsent: () => 1,
         );
       }
+      final bitrateResults = audit
+          .where((entry) => requiredBitrateFeatures.contains(entry['feature']))
+          .toList();
+      final bitrateFailures = bitrateResults
+          .where((entry) => entry['status'] != 'PASS')
+          .toList();
+      expect(bitrateResults, hasLength(requiredBitrateFeatures.length));
+      expect(
+        bitrateFailures,
+        isEmpty,
+        reason:
+            'Required bitrate regressions failed: ${jsonEncode(bitrateFailures)}',
+      );
       // Intentionally machine-readable for the opt-in simulator audit command.
       // ignore: avoid_print
       print('VVC_IOS_AUDIT_SUMMARY|${jsonEncode(summary)}');

--- a/ios/v_video_compressor/Sources/v_video_compressor/VVideoCompressionEngine.swift
+++ b/ios/v_video_compressor/Sources/v_video_compressor/VVideoCompressionEngine.swift
@@ -247,7 +247,8 @@ class VVideoCompressionEngine {
         // limit has to be computed over the duration that is actually exported.
         applyFileLengthLimit(
             exportSession: exportSession,
-            asset: exportAsset,
+            sourceAsset: asset,
+            exportAsset: exportAsset,
             config: config,
             removesAudio: removesAudio
         )
@@ -276,52 +277,45 @@ class VVideoCompressionEngine {
                advanced.customHeight != nil || advanced.autoCorrectOrientation == true
     }
 
-    /// Caps the export size so the output honours the requested bitrate.
+    /// Caps the export size when the caller explicitly requests a video bitrate.
     ///
-    /// `AVAssetExportSession` exposes no bitrate setting, and the export presets
-    /// are quality-targeted rather than rate-targeted: the very same
-    /// `AVAssetExportPreset1280x720` yields ~1.6 Mbps on the macOS media stack
-    /// (Simulator) and ~10.5 Mbps on a device for one identical 1080p source —
-    /// output bigger than the input, which is what `videoBitrate` is supposed to
-    /// prevent. Android already feeds `videoBitrate` straight to MediaCodec, so
-    /// without this the same config produces wildly different files per platform.
-    ///
-    /// `fileLengthLimit` is the only rate knob AVFoundation offers on an export
-    /// session. Apple documents it as a limit the output "must not exceed", with
-    /// the caveat that it may slightly overshoot — it degrades quality to comply
-    /// rather than failing the export. `canPerformMultiplePassesOverSourceMediaData`
-    /// is enabled above, which is what lets the encoder actually hit the target.
+    /// `AVAssetExportSession` has no per-track bitrate setting, so the requested
+    /// video rate is approximated with a total file-length budget. Exports that
+    /// rely only on a quality preset are deliberately left unchanged.
     private func applyFileLengthLimit(
         exportSession: AVAssetExportSession,
-        asset: AVAsset,
+        sourceAsset: AVAsset,
+        exportAsset: AVAsset,
         config: VVideoCompressionConfig,
         removesAudio: Bool
     ) {
-        let videoBitrate = config.advanced?.videoBitrate ?? getDefaultBitrate(for: config.quality)
+        guard let videoBitrate = config.advanced?.videoBitrate else { return }
 
-        let audioBitrate: Int
-        if removesAudio {
-            audioBitrate = 0
-        } else if let configured = config.advanced?.audioBitrate {
-            audioBitrate = configured
-        } else {
-            // Presets keep the source audio rate when it is already modest, so
-            // measuring the track beats assuming the 128 kbps default.
-            let sourceRate = asset.tracks(withMediaType: .audio).first?.estimatedDataRate ?? 0
-            audioBitrate = sourceRate > 0 ? Int(sourceRate) : Self.AUDIO_BITRATE
-        }
+        // The exporter does not independently enforce `audioBitrate`. Budget
+        // the audio rate it is expected to preserve so an unenforced setting
+        // cannot accidentally give bandwidth to, or take it from, the video.
+        let audioTrack = sourceAsset.tracks(withMediaType: .audio).first
+        let audioBitrate = VVideoFileLengthBudget.audioBitrate(
+            removesAudio: removesAudio,
+            hasAudioTrack: audioTrack != nil,
+            estimatedAudioBitrate: audioTrack.map { Double($0.estimatedDataRate) }
+        )
 
         // The default timeRange is 0...+infinity; only a trim makes it numeric.
         let range = exportSession.timeRange
-        let duration = range.duration.isNumeric ? range.duration : asset.duration
+        let duration = range.duration.isNumeric ? range.duration : exportAsset.duration
         let seconds = CMTimeGetSeconds(duration)
-        guard seconds.isFinite, seconds > 0 else { return }
-
-        let limit = Int64((Double(videoBitrate + audioBitrate) * seconds) / 8.0)
-        guard limit > 0 else { return }
+        guard let limit = VVideoFileLengthBudget.fileLengthLimit(
+            explicitVideoBitrate: videoBitrate,
+            audioBitrate: audioBitrate,
+            durationSeconds: seconds
+        ) else { return }
 
         exportSession.fileLengthLimit = limit
-        print("VVideoCompressionEngine: fileLengthLimit \(limit)B from \(videoBitrate + audioBitrate)bps over \(seconds)s")
+        print(
+            "VVideoCompressionEngine: fileLengthLimit \(limit)B " +
+            "from video=\(videoBitrate)bps audio=\(audioBitrate)bps over \(seconds)s"
+        )
     }
 
     private func createRotationTransform(angle: Int, sourceSize: CGSize, targetSize: CGSize) -> CGAffineTransform {
@@ -872,7 +866,14 @@ class VVideoCompressionEngine {
         if let advanced = config.advanced {
             if let width = advanced.customWidth, width <= 0 { return false }
             if let height = advanced.customHeight, height <= 0 { return false }
-            if let bitrate = advanced.videoBitrate, bitrate <= 0 { return false }
+            if let bitrate = advanced.videoBitrate,
+               bitrate <= 0 || bitrate > VVideoFileLengthBudget.maximumBitrate {
+                return false
+            }
+            if let bitrate = advanced.audioBitrate,
+               bitrate <= 0 || bitrate > VVideoFileLengthBudget.maximumBitrate {
+                return false
+            }
             if let frameRate = advanced.frameRate, frameRate <= 0 { return false }
         }
         

--- a/ios/v_video_compressor/Sources/v_video_compressor/VVideoCompressionEngine.swift
+++ b/ios/v_video_compressor/Sources/v_video_compressor/VVideoCompressionEngine.swift
@@ -242,7 +242,16 @@ class VVideoCompressionEngine {
                 trimAlreadyApplied: trimAlreadyApplied
             )
         }
-        
+
+        // Applied last: trimming above narrows exportSession.timeRange, and the
+        // limit has to be computed over the duration that is actually exported.
+        applyFileLengthLimit(
+            exportSession: exportSession,
+            asset: exportAsset,
+            config: config,
+            removesAudio: removesAudio
+        )
+
         startProgressTracking(callback: callback)
         
         // iOS Quick Fix: Background processing optimization
@@ -265,6 +274,54 @@ class VVideoCompressionEngine {
                advanced.trimStartMs != nil || advanced.trimEndMs != nil ||
                advanced.removeAudio == true || advanced.customWidth != nil ||
                advanced.customHeight != nil || advanced.autoCorrectOrientation == true
+    }
+
+    /// Caps the export size so the output honours the requested bitrate.
+    ///
+    /// `AVAssetExportSession` exposes no bitrate setting, and the export presets
+    /// are quality-targeted rather than rate-targeted: the very same
+    /// `AVAssetExportPreset1280x720` yields ~1.6 Mbps on the macOS media stack
+    /// (Simulator) and ~10.5 Mbps on a device for one identical 1080p source —
+    /// output bigger than the input, which is what `videoBitrate` is supposed to
+    /// prevent. Android already feeds `videoBitrate` straight to MediaCodec, so
+    /// without this the same config produces wildly different files per platform.
+    ///
+    /// `fileLengthLimit` is the only rate knob AVFoundation offers on an export
+    /// session. Apple documents it as a limit the output "must not exceed", with
+    /// the caveat that it may slightly overshoot — it degrades quality to comply
+    /// rather than failing the export. `canPerformMultiplePassesOverSourceMediaData`
+    /// is enabled above, which is what lets the encoder actually hit the target.
+    private func applyFileLengthLimit(
+        exportSession: AVAssetExportSession,
+        asset: AVAsset,
+        config: VVideoCompressionConfig,
+        removesAudio: Bool
+    ) {
+        let videoBitrate = config.advanced?.videoBitrate ?? getDefaultBitrate(for: config.quality)
+
+        let audioBitrate: Int
+        if removesAudio {
+            audioBitrate = 0
+        } else if let configured = config.advanced?.audioBitrate {
+            audioBitrate = configured
+        } else {
+            // Presets keep the source audio rate when it is already modest, so
+            // measuring the track beats assuming the 128 kbps default.
+            let sourceRate = asset.tracks(withMediaType: .audio).first?.estimatedDataRate ?? 0
+            audioBitrate = sourceRate > 0 ? Int(sourceRate) : Self.AUDIO_BITRATE
+        }
+
+        // The default timeRange is 0...+infinity; only a trim makes it numeric.
+        let range = exportSession.timeRange
+        let duration = range.duration.isNumeric ? range.duration : asset.duration
+        let seconds = CMTimeGetSeconds(duration)
+        guard seconds.isFinite, seconds > 0 else { return }
+
+        let limit = Int64((Double(videoBitrate + audioBitrate) * seconds) / 8.0)
+        guard limit > 0 else { return }
+
+        exportSession.fileLengthLimit = limit
+        print("VVideoCompressionEngine: fileLengthLimit \(limit)B from \(videoBitrate + audioBitrate)bps over \(seconds)s")
     }
 
     private func createRotationTransform(angle: Int, sourceSize: CGSize, targetSize: CGSize) -> CGAffineTransform {

--- a/ios/v_video_compressor/Sources/v_video_compressor/VVideoFileLengthBudget.swift
+++ b/ios/v_video_compressor/Sources/v_video_compressor/VVideoFileLengthBudget.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Calculates the total-byte budget used to approximate an explicit video
+/// bitrate with `AVAssetExportSession.fileLengthLimit`.
+enum VVideoFileLengthBudget {
+    static let fallbackAudioBitrate = 128_000
+    static let maximumBitrate = Int(Int32.max)
+
+    static func audioBitrate(
+        removesAudio: Bool,
+        hasAudioTrack: Bool,
+        estimatedAudioBitrate: Double?
+    ) -> Int {
+        guard !removesAudio, hasAudioTrack else { return 0 }
+        guard let estimatedAudioBitrate = estimatedAudioBitrate,
+              estimatedAudioBitrate.isFinite,
+              estimatedAudioBitrate >= 1,
+              estimatedAudioBitrate <= Double(maximumBitrate) else {
+            return fallbackAudioBitrate
+        }
+        return Int(estimatedAudioBitrate.rounded(.down))
+    }
+
+    static func fileLengthLimit(
+        explicitVideoBitrate: Int?,
+        audioBitrate: Int,
+        durationSeconds: Double
+    ) -> Int64? {
+        guard let videoBitrate = explicitVideoBitrate,
+              videoBitrate > 0,
+              videoBitrate <= maximumBitrate,
+              audioBitrate >= 0,
+              audioBitrate <= maximumBitrate,
+              durationSeconds.isFinite,
+              durationSeconds > 0 else {
+            return nil
+        }
+
+        // Convert each operand before adding so an extreme pair of Int values
+        // cannot overflow before the range check below.
+        let totalBitrate = Double(videoBitrate) + Double(audioBitrate)
+        let bytes = totalBitrate * durationSeconds / 8.0
+        guard bytes.isFinite,
+              bytes >= 1,
+              bytes < Double(Int64.max) else {
+            return nil
+        }
+        return Int64(bytes.rounded(.down))
+    }
+}

--- a/ios/v_video_compressor/Tests/v_video_compressorTests/VVideoFileLengthBudgetTests.swift
+++ b/ios/v_video_compressor/Tests/v_video_compressorTests/VVideoFileLengthBudgetTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import v_video_compressor
+
+final class VVideoFileLengthBudgetTests: XCTestCase {
+    func testNoExplicitVideoBitratePreservesPresetBehavior() {
+        XCTAssertNil(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: nil,
+                audioBitrate: 128_000,
+                durationSeconds: 10
+            )
+        )
+    }
+
+    func testVideoOnlyBudgetDoesNotReserveAudioBytes() {
+        let audioBitrate = VVideoFileLengthBudget.audioBitrate(
+            removesAudio: false,
+            hasAudioTrack: false,
+            estimatedAudioBitrate: nil
+        )
+
+        XCTAssertEqual(audioBitrate, 0)
+        XCTAssertEqual(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: 250_000,
+                audioBitrate: audioBitrate,
+                durationSeconds: 10
+            ),
+            312_500
+        )
+    }
+
+    func testPreservedAudioUsesTheSourceTrackEstimate() {
+        let audioBitrate = VVideoFileLengthBudget.audioBitrate(
+            removesAudio: false,
+            hasAudioTrack: true,
+            estimatedAudioBitrate: 96_000
+        )
+
+        XCTAssertEqual(audioBitrate, 96_000)
+        XCTAssertEqual(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: 250_000,
+                audioBitrate: audioBitrate,
+                durationSeconds: 10
+            ),
+            432_500
+        )
+    }
+
+    func testRemovedAudioOverridesTheSourceTrackEstimate() {
+        XCTAssertEqual(
+            VVideoFileLengthBudget.audioBitrate(
+                removesAudio: true,
+                hasAudioTrack: true,
+                estimatedAudioBitrate: 256_000
+            ),
+            0
+        )
+    }
+
+    func testUnknownSourceAudioRateUsesConservativeFallback() {
+        XCTAssertEqual(
+            VVideoFileLengthBudget.audioBitrate(
+                removesAudio: false,
+                hasAudioTrack: true,
+                estimatedAudioBitrate: nil
+            ),
+            128_000
+        )
+        XCTAssertEqual(
+            VVideoFileLengthBudget.audioBitrate(
+                removesAudio: false,
+                hasAudioTrack: true,
+                estimatedAudioBitrate: .nan
+            ),
+            128_000
+        )
+        XCTAssertEqual(
+            VVideoFileLengthBudget.audioBitrate(
+                removesAudio: false,
+                hasAudioTrack: true,
+                estimatedAudioBitrate: 0.5
+            ),
+            128_000
+        )
+    }
+
+    func testTrimmedDurationControlsTheBudget() {
+        XCTAssertEqual(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: 250_000,
+                audioBitrate: 128_000,
+                durationSeconds: 2.5
+            ),
+            118_125
+        )
+    }
+
+    func testInvalidAndOverflowingInputsAreRejected() {
+        XCTAssertNil(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: 0,
+                audioBitrate: 0,
+                durationSeconds: 1
+            )
+        )
+        XCTAssertNil(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: 250_000,
+                audioBitrate: -1,
+                durationSeconds: 1
+            )
+        )
+        XCTAssertNil(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: 250_000,
+                audioBitrate: 0,
+                durationSeconds: .infinity
+            )
+        )
+        XCTAssertNil(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: Int.max,
+                audioBitrate: Int.max,
+                durationSeconds: 10
+            )
+        )
+        XCTAssertNil(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: VVideoFileLengthBudget.maximumBitrate + 1,
+                audioBitrate: 0,
+                durationSeconds: 1
+            )
+        )
+        XCTAssertNil(
+            VVideoFileLengthBudget.fileLengthLimit(
+                explicitVideoBitrate: 250_000,
+                audioBitrate: VVideoFileLengthBudget.maximumBitrate + 1,
+                durationSeconds: 1
+            )
+        )
+    }
+}

--- a/lib/src/v_video_models.dart
+++ b/lib/src/v_video_models.dart
@@ -201,10 +201,22 @@ class VVideoCropRect {
 
 /// Advanced video compression configuration
 class VVideoAdvancedConfig {
-  /// Custom video bitrate in bits per second (overrides quality preset)
+  static const int _maximumNativeBitrate = 0x7fffffff;
+
+  /// Custom video bitrate in bits per second (overrides quality preset).
+  ///
+  /// Must be between 1 and 2,147,483,647.
+  ///
+  /// On iOS this is approximated with an export file-length budget, so the
+  /// encoded bitrate can vary slightly from the requested value.
   final int? videoBitrate;
 
-  /// Custom audio bitrate in bits per second
+  /// Custom audio bitrate in bits per second.
+  ///
+  /// Must be between 1 and 2,147,483,647.
+  ///
+  /// AVAssetExportSession selects the audio bitrate on iOS; this remains an
+  /// independent encoder setting only on platforms that expose that control.
   final int? audioBitrate;
 
   /// Custom resolution width (must be used with height)
@@ -339,6 +351,16 @@ class VVideoAdvancedConfig {
           customHeight! % 2 != 0) {
         return false;
       }
+    }
+
+    if (videoBitrate != null &&
+        (videoBitrate! <= 0 || videoBitrate! > _maximumNativeBitrate)) {
+      return false;
+    }
+
+    if (audioBitrate != null &&
+        (audioBitrate! <= 0 || audioBitrate! > _maximumNativeBitrate)) {
+      return false;
     }
 
     // Frame rate must be positive

--- a/test/v_video_compressor_test.dart
+++ b/test/v_video_compressor_test.dart
@@ -505,6 +505,40 @@ void main() {
         expect(config.isValid(), isTrue);
       });
 
+      test('should reject non-positive video and audio bitrates', () {
+        expect(
+          const VVideoAdvancedConfig(videoBitrate: 0).isValid(),
+          isFalse,
+        );
+        expect(
+          const VVideoAdvancedConfig(videoBitrate: -1).isValid(),
+          isFalse,
+        );
+        expect(
+          const VVideoAdvancedConfig(audioBitrate: 0).isValid(),
+          isFalse,
+        );
+        expect(
+          const VVideoAdvancedConfig(audioBitrate: -1).isValid(),
+          isFalse,
+        );
+        expect(
+          const VVideoAdvancedConfig(videoBitrate: 0x80000000).isValid(),
+          isFalse,
+        );
+        expect(
+          const VVideoAdvancedConfig(audioBitrate: 0x80000000).isValid(),
+          isFalse,
+        );
+        expect(
+          const VVideoAdvancedConfig(
+            videoBitrate: 250000,
+            audioBitrate: 128000,
+          ).isValid(),
+          isTrue,
+        );
+      });
+
       test('should validate autoCorrectOrientation parameter', () {
         final advancedWithOrientation = VVideoAdvancedConfig(
           autoCorrectOrientation: true,


### PR DESCRIPTION
## Problem

On iOS, `videoBitrate` was used for size estimates but did not control the actual `AVAssetExportSession` export. AVFoundation presets are quality-targeted, so the same preset can produce substantially different rates on Simulator and physical devices.

The original author measured one 30.5 s H.264 source as:

| Environment | Resolution | Video bitrate | Output |
|---|---:|---:|---:|
| Simulator | 1280x720 | 1.65 Mbps | 6.9 MB |
| iPhone | 1280x720 | 10.51 Mbps | 38.6 MB |

## Fix

Use `AVAssetExportSession.fileLengthLimit` to approximate the requested video bitrate, with these safeguards:

- Apply the limit only when the caller explicitly supplies `videoBitrate`; preset-only exports retain their previous behavior.
- Budget audio only when an audio track will be exported.
- Use the source audio track's measured rate because `AVAssetExportSession` does not independently enforce `audioBitrate`.
- Use the effective exported duration, including trims already applied inside a composition.
- Validate positive 32-bit-native bitrate values.
- Calculate the byte limit with overflow-safe arithmetic.
- Keep the calculation isolated and unit tested.

`fileLengthLimit` is a total-byte approximation and AVFoundation can exceed it, particularly for short clips.

## Platform scope

This PR changes iOS behavior only. It does not add or claim Android encoder-bitrate enforcement.

## Validation

Completed on the updated PR head:

- `flutter analyze`
- `flutter test` — 95 tests passed
- `cd example && flutter test test` — 3 tests passed
- Swift file-budget suite — 7 tests passed
- `flutter build ios --no-codesign` — succeeded
- iPhone 16 Pro Simulator, iOS 18.2 — mandatory bitrate regressions passed:
  - H.264 with audio
  - H.264 without audio
  - trimmed H.264
  - trimmed composition without audio
  - H.265
- `git diff --check`

The broader diagnostic iOS audit still records unrelated legacy gaps; the five bitrate cases above are explicit test assertions.

## Physical-device evidence

The original author reported that the 30.5 s device output fell from 40,505,118 bytes to 8,339,537 bytes, with video bitrate falling from 10.51 Mbps to 1.95 Mbps. That result supports the approach, but the new hardening commit has not yet been independently rerun on a physical iPhone.
